### PR TITLE
Dynamic Light Threshold

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text eol=lf

--- a/include/LightSensor.hpp
+++ b/include/LightSensor.hpp
@@ -1,3 +1,5 @@
+#define BUFFER_SIZE 64
+
 class LightSensor {
 private:
   int pin;
@@ -6,6 +8,11 @@ private:
   bool trainDetected;
   unsigned long timeout;
   const unsigned long timeoutThreshold;
+  int lightBuffer[BUFFER_SIZE];
+  int lightBufferIndex;
+  bool bufferFull;
+
+  int getAverageLightLevel();
 
 public:
   LightSensor(int sensorPin, int detectionThreshold);

--- a/include/LightSensor.hpp
+++ b/include/LightSensor.hpp
@@ -11,8 +11,10 @@ private:
   int lightBuffer[BUFFER_SIZE];
   int lightBufferIndex;
   bool bufferFull;
+  int lastAverage;
 
   int getAverageLightLevel();
+  int getDynamicThreshold(int average);
 
 public:
   LightSensor(int sensorPin, int detectionThreshold);

--- a/src/BluetoothController.cpp
+++ b/src/BluetoothController.cpp
@@ -10,61 +10,61 @@ BluetoothController::BluetoothController(Lpf2Hub* hub)
 }
 
 bool BluetoothController::connect() {
-  if (!trainHub->isConnected() && !trainHub->isConnecting()) {
-    trainHub->init(); // initalize the PoweredUpHub instance
-  }
+    if (!trainHub->isConnected() && !trainHub->isConnecting()) {
+        trainHub->init(); // initalize the PoweredUpHub instance
+    }
 
-  if (!trainHub->isConnecting()) {
-    // If we are already connected, we do not need to connect again.
+    if (!trainHub->isConnecting()) {
+        // If we are already connected, we do not need to connect again.
+        return true;
+    }
+
+    trainHub->connectHub();
+
+    if (!trainHub->isConnected()) {
+        Serial.println("Failed to connect to HUB");
+        return false;
+    }
+
+    Serial.println("Connected to HUB");
+    Serial.print("Hub address: ");
+    Serial.println(this->getHubAddress().c_str());
+    Serial.print("Hub name: ");
+    Serial.println(this->getHubName().c_str());
+
     return true;
-  }
-
-  trainHub->connectHub();
-
-  if (!trainHub->isConnected()) {
-    Serial.println("Failed to connect to HUB");
-    return false;
-  }
-
-  Serial.println("Connected to HUB");
-  Serial.print("Hub address: ");
-  Serial.println(this->getHubAddress().c_str());
-  Serial.print("Hub name: ");
-  Serial.println(this->getHubName().c_str());
-
-  return true;
 }
 
 bool BluetoothController::isConnected() const {
-    return trainHub->isConnected();
+        return trainHub->isConnected();
 }
 
 void BluetoothController::setMotorSpeed(byte port, int speed) {
-    if (!isConnected()) {
-        return;
-    }
-    trainHub->setBasicMotorSpeed(port, speed);
+        if (!isConnected()) {
+                return;
+        }
+        trainHub->setBasicMotorSpeed(port, speed);
 }
 
 void BluetoothController::setHubName(const char* name) {
-    if (!isConnected()) {
-        return;
-    }
-    trainHub->setHubName((char*) name);
+        if (!isConnected()) {
+                return;
+        }
+        trainHub->setHubName((char*) name);
 }
 
 String BluetoothController::getHubAddress() {
-    if (!isConnected()) {
-        Serial.println("Cannot get hub address: Not connected to hub");
-        return String();
-    }
-    return trainHub->getHubAddress().toString().c_str();
+        if (!isConnected()) {
+                Serial.println("Cannot get hub address: Not connected to hub");
+                return String();
+        }
+        return trainHub->getHubAddress().toString().c_str();
 }
 
 String BluetoothController::getHubName() {
-    if (!isConnected()) {
-        Serial.println("Cannot get hub name: Not connected to hub");
-        return String();
-    }
-    return trainHub->getHubName().c_str();
+        if (!isConnected()) {
+                Serial.println("Cannot get hub name: Not connected to hub");
+                return String();
+        }
+        return trainHub->getHubName().c_str();
 }

--- a/src/InputController.cpp
+++ b/src/InputController.cpp
@@ -5,40 +5,40 @@
 InputController::InputController(TrainController* controller, int fastButtonPin, int slowButtonPin)
 : trainController(controller), fastButton(fastButtonPin), slowButton(slowButtonPin)
 {
-  pinMode(fastButton, INPUT_PULLUP);
-  pinMode(slowButton, INPUT_PULLUP);
+    pinMode(fastButton, INPUT_PULLUP);
+    pinMode(slowButton, INPUT_PULLUP);
 }
 
 void InputController::handleButtonInput() {
-  int fastButtonState = digitalRead(fastButton);
-  int slowButtonState = digitalRead(slowButton);
+    int fastButtonState = digitalRead(fastButton);
+    int slowButtonState = digitalRead(slowButton);
 
-  if (fastButtonState == LOW && slowButtonState == LOW) {
-    trainController->setState(STOPPED);
-    delay(100);
-  } else if (fastButtonState == LOW) {  // button pressed
-    trainController->setState(FAST);
-  } else if (slowButtonState == LOW) {  // button pressed
-    trainController->setState(SLOW);
-  }
+    if (fastButtonState == LOW && slowButtonState == LOW) {
+        trainController->setState(STOPPED);
+        delay(100);
+    } else if (fastButtonState == LOW) {    // button pressed
+        trainController->setState(FAST);
+    } else if (slowButtonState == LOW) {    // button pressed
+        trainController->setState(SLOW);
+    }
 }
 
 void InputController::handleSerialInput() {
-  const char STOP_COMMAND[] = "stop";
-  const int STOP_COMMAND_LENGTH = sizeof(STOP_COMMAND) - 1;
-  const char SLOW_COMMAND[] = "slow";
-  const int SLOW_COMMAND_LENGTH = sizeof(STOP_COMMAND) - 1;
-  const char FAST_COMMAND[] = "fast";
-  const int FAST_COMMAND_LENGTH = sizeof(STOP_COMMAND) - 1;
+    const char STOP_COMMAND[] = "stop";
+    const int STOP_COMMAND_LENGTH = sizeof(STOP_COMMAND) - 1;
+    const char SLOW_COMMAND[] = "slow";
+    const int SLOW_COMMAND_LENGTH = sizeof(STOP_COMMAND) - 1;
+    const char FAST_COMMAND[] = "fast";
+    const int FAST_COMMAND_LENGTH = sizeof(STOP_COMMAND) - 1;
 
-  String recievedData = "";
+    String recievedData = "";
 
-  if (Serial.available() <= 0) return;
+    if (Serial.available() <= 0) return;
 
-  recievedData = Serial.readStringUntil('\n');
-  recievedData.trim();
+    recievedData = Serial.readStringUntil('\n');
+    recievedData.trim();
 
-  if (recievedData.equals(STOP_COMMAND)) trainController->setState(STOPPED);
-  if (recievedData.equals(SLOW_COMMAND)) trainController->setState(SLOW);
-  if (recievedData.equals(FAST_COMMAND)) trainController->setState(FAST);
+    if (recievedData.equals(STOP_COMMAND)) trainController->setState(STOPPED);
+    if (recievedData.equals(SLOW_COMMAND)) trainController->setState(SLOW);
+    if (recievedData.equals(FAST_COMMAND)) trainController->setState(FAST);
 }

--- a/src/LightSensor.cpp
+++ b/src/LightSensor.cpp
@@ -8,9 +8,14 @@ LightSensor::LightSensor(int sensorPin, int detectionThreshold)
   lastReading(0),
   trainDetected(false),
   timeout(0),
-  timeoutThreshold(500) // Default timeout threshold of 500 milliseconds
+  timeoutThreshold(500), // Default timeout threshold of 500 milliseconds
+  lastAverage(0)
 {
   pinMode(pin, INPUT);
+}
+
+int LightSensor::getDynamicThreshold(int average) {
+  return average * (1 - (threshold / 100.0));
 }
 
 /**
@@ -18,24 +23,33 @@ LightSensor::LightSensor(int sensorPin, int detectionThreshold)
  * @return The light level as an integer.
  */
 int LightSensor::readLevel() {
-  lastReading = analogRead(pin);
-  lightBuffer[lightBufferIndex] = lastReading;
-  lightBufferIndex = (lightBufferIndex + 1) % BUFFER_SIZE;
-  if (lightBufferIndex == 0) {
-    bufferFull = true;
+  // Always read the latest value
+  int newReading = analogRead(pin);
+
+  // Calculate average and threshold BEFORE updating buffer
+  int average = getAverageLightLevel();
+  int dynamicThreshold = getDynamicThreshold(average);
+  bool trainPassing = newReading < dynamicThreshold;
+
+  // Only update buffer if not passing (i.e., normal light)
+  if (!trainPassing) {
+    lightBuffer[lightBufferIndex] = newReading;
+    lightBufferIndex = (lightBufferIndex + 1) % BUFFER_SIZE;
+    if (lightBufferIndex == 0) bufferFull = true;
   }
-  return lastReading;
+
+  return newReading; // Return the latest reading
 }
 
 bool LightSensor::isTrainPassingOver(int lightReading) {
   int average = getAverageLightLevel();
-  int dynamicThreshold = average * (1 - (threshold / 100.0)); // Adjust threshold based on average light level
-  return lightReading < dynamicThreshold;
+  int dynamicThreshold = getDynamicThreshold(average); // Adjust threshold based on average light level
+  bool isPassing = lightReading < dynamicThreshold;
+  return isPassing;
 }
 
 bool LightSensor::detectPassingTrain() {
-  int currentLightReading = readLevel();
-  bool trainPassing = isTrainPassingOver(currentLightReading);
+  bool trainPassing = isTrainPassingOver(readLevel());
 
   // If the timeout hasn't been reached, we do not detect a train, irrespective of
   // if the light sensor is triggered or not.

--- a/src/LightSensor.cpp
+++ b/src/LightSensor.cpp
@@ -19,11 +19,18 @@ LightSensor::LightSensor(int sensorPin, int detectionThreshold)
  */
 int LightSensor::readLevel() {
   lastReading = analogRead(pin);
+  lightBuffer[lightBufferIndex] = lastReading;
+  lightBufferIndex = (lightBufferIndex + 1) % BUFFER_SIZE;
+  if (lightBufferIndex == 0) {
+    bufferFull = true;
+  }
   return lastReading;
 }
 
 bool LightSensor::isTrainPassingOver(int lightReading) {
-  return lightReading < threshold;
+  int average = getAverageLightLevel();
+  int dynamicThreshold = average * (1 - (threshold / 100.0)); // Adjust threshold based on average light level
+  return lightReading < dynamicThreshold;
 }
 
 bool LightSensor::detectPassingTrain() {
@@ -66,4 +73,15 @@ void LightSensor::reset() {
   trainDetected = false;
   timeout = 0;
   lastReading = 0;
+}
+
+int LightSensor::getAverageLightLevel() {
+  int sum = 0;
+  int count = bufferFull ? BUFFER_SIZE : lightBufferIndex;
+
+  for (int i = 0; i < count; i++) {
+    sum += lightBuffer[i];
+  }
+
+  return (count > 0) ? (sum / count) : 0; // Return average or 0 if no valid readings
 }

--- a/src/LightSensor.cpp
+++ b/src/LightSensor.cpp
@@ -4,18 +4,18 @@
 // Constructor
 LightSensor::LightSensor(int sensorPin, int detectionThreshold)
 : pin(sensorPin),
-  threshold(detectionThreshold),
-  lastReading(0),
-  trainDetected(false),
-  timeout(0),
-  timeoutThreshold(500), // Default timeout threshold of 500 milliseconds
-  lastAverage(0)
+    threshold(detectionThreshold),
+    lastReading(0),
+    trainDetected(false),
+    timeout(0),
+    timeoutThreshold(500), // Default timeout threshold of 500 milliseconds
+    lastAverage(0)
 {
-  pinMode(pin, INPUT);
+    pinMode(pin, INPUT);
 }
 
 int LightSensor::getDynamicThreshold(int average) {
-  return average * (1 - (threshold / 100.0));
+    return average * (1 - (threshold / 100.0));
 }
 
 /**
@@ -23,79 +23,79 @@ int LightSensor::getDynamicThreshold(int average) {
  * @return The light level as an integer.
  */
 int LightSensor::readLevel() {
-  // Always read the latest value
-  int newReading = analogRead(pin);
+    // Always read the latest value
+    int newReading = analogRead(pin);
 
-  // Calculate average and threshold BEFORE updating buffer
-  int average = getAverageLightLevel();
-  int dynamicThreshold = getDynamicThreshold(average);
-  bool trainPassing = newReading < dynamicThreshold;
+    // Calculate average and threshold BEFORE updating buffer
+    int average = getAverageLightLevel();
+    int dynamicThreshold = getDynamicThreshold(average);
+    bool trainPassing = newReading < dynamicThreshold;
 
-  // Only update buffer if not passing (i.e., normal light)
-  if (!trainPassing) {
-    lightBuffer[lightBufferIndex] = newReading;
-    lightBufferIndex = (lightBufferIndex + 1) % BUFFER_SIZE;
-    if (lightBufferIndex == 0) bufferFull = true;
-  }
+    // Only update buffer if not passing (i.e., normal light)
+    if (!trainPassing) {
+        lightBuffer[lightBufferIndex] = newReading;
+        lightBufferIndex = (lightBufferIndex + 1) % BUFFER_SIZE;
+        if (lightBufferIndex == 0) bufferFull = true;
+    }
 
-  return newReading; // Return the latest reading
+    return newReading; // Return the latest reading
 }
 
 bool LightSensor::isTrainPassingOver(int lightReading) {
-  int average = getAverageLightLevel();
-  int dynamicThreshold = getDynamicThreshold(average); // Adjust threshold based on average light level
-  bool isPassing = lightReading < dynamicThreshold;
-  return isPassing;
+    int average = getAverageLightLevel();
+    int dynamicThreshold = getDynamicThreshold(average); // Adjust threshold based on average light level
+    bool isPassing = lightReading < dynamicThreshold;
+    return isPassing;
 }
 
 bool LightSensor::detectPassingTrain() {
-  bool trainPassing = isTrainPassingOver(readLevel());
+    bool trainPassing = isTrainPassingOver(readLevel());
 
-  // If the timeout hasn't been reached, we do not detect a train, irrespective of
-  // if the light sensor is triggered or not.
-  if (millis() - timeout <= timeoutThreshold) {
-    return false;
-  } else if (timeout != 0) {
-    timeout = 0;
-  }
+    // If the timeout hasn't been reached, we do not detect a train, irrespective of
+    // if the light sensor is triggered or not.
+    if (millis() - timeout <= timeoutThreshold) {
+        return false;
+    } else if (timeout != 0) {
+        timeout = 0;
+    }
 
-  // Condition 1: If train is currently passing over and has not been detected before,
-  // we set detected to true.
-  if (trainPassing && !trainDetected) {
-    Serial.println("--- TRAIN DETECTED! ---");
-    trainDetected = true;
-    timeout = millis();
-    return true;
-  } 
-  // Condition 2: If train has passed over and has been detected before,
-  // we reset the condition assuming the train has cleared the sensor.
-  else if (!trainPassing && trainDetected) {
-    Serial.println("--- TRAIN CLEARED! ---");
-    trainDetected = false;
-    timeout = millis();
-    return false;
-  }
-  
-  return false; // No change in detection state
+    // Condition 1: If train is currently passing over and has not been detected before,
+    // we set detected to true.
+    if (trainPassing && !trainDetected) {
+        Serial.println("--- TRAIN DETECTED! ---");
+        trainDetected = true;
+        timeout = millis();
+        return true;
+    } 
+    // Condition 2: If train has passed over and has been detected before,
+    // we reset the condition assuming the train has cleared the sensor.
+    else if (!trainPassing && trainDetected) {
+        Serial.println("--- TRAIN CLEARED! ---");
+        trainDetected = false;
+        timeout = millis();
+        return false;
+    }
+    
+    return false; // No change in detection state
 }
 
 bool LightSensor::isTrainDetected() const {
-  return trainDetected;
+    return trainDetected;
 }
 
 void LightSensor::reset() {
-  trainDetected = false;
-  timeout = 0;
-  lastReading = 0;
+    trainDetected = false;
+    timeout = 0;
+    lastReading = 0;
 }
 
 int LightSensor::getAverageLightLevel() {
-  int sum = 0;
-  int count = bufferFull ? BUFFER_SIZE : lightBufferIndex;
+    int sum = 0;
+    int count = bufferFull ? BUFFER_SIZE : lightBufferIndex;
 
-  for (int i = 0; i < count; i++) {
-    sum += lightBuffer[i];
-  }
+    for (int i = 0; i < count; i++) {
+        sum += lightBuffer[i];
+    }
 
-  return (count > 0) ? (sum / count) : 0; // Return average or 0 if no valid readings
+    return (count > 0) ? (sum / count) : 0; // Return average or 0 if no valid readings
 }

--- a/src/TrainController.cpp
+++ b/src/TrainController.cpp
@@ -3,65 +3,65 @@
 
 // Constructor
 TrainController::TrainController(byte motorPort)
-  : trainState(STOPPED),
-    stateChanged(false),
-    previousMillis(0),
-    speedSwitchInterval(100), // 100ms default interval for speed switching
-    port(motorPort)
+    : trainState(STOPPED),
+        stateChanged(false),
+        previousMillis(0),
+        speedSwitchInterval(100), // 100ms default interval for speed switching
+        port(motorPort)
 {}
 
 // Set the train state and mark as changed if different
 void TrainController::setState(SPEED newState) {
-  if (trainState != newState) {
-    trainState = newState;
-    stateChanged = true;
-  } else {
-    stateChanged = false; // No change if the state is the same
-  }
+    if (trainState != newState) {
+        trainState = newState;
+        stateChanged = true;
+    } else {
+        stateChanged = false; // No change if the state is the same
+    }
 }
 
 // Get the current train state
 SPEED TrainController::getState() {
-  return trainState;
+    return trainState;
 }
 
 // Check if the state has changed since last clear
 bool TrainController::hasStateChanged() {
-  return stateChanged;
+    return stateChanged;
 }
 
 // Clear the state changed flag
 void TrainController::clearStateChanged() {
-  stateChanged = false;
+    stateChanged = false;
 }
 
 // Get the speed value for a given state
 int TrainController::getSpeed(SPEED state) {
-  switch (state) {
-    case FAST: return 30;
-    case SLOW: return 15;
-    case STOPPED:
-    default: return 0;
-  }
+    switch (state) {
+        case FAST: return 30;
+        case SLOW: return 15;
+        case STOPPED:
+        default: return 0;
+    }
 }
 
 // Check if enough time has passed to update speed
 bool TrainController::canUpdateSpeed() {
-  return (millis() - previousMillis) >= speedSwitchInterval;
+    return (millis() - previousMillis) >= speedSwitchInterval;
 }
 
 // Update the timer for speed switching
 void TrainController::updateSpeedTimer() {
-  previousMillis = millis();
+    previousMillis = millis();
 }
 
 // Print the current state to Serial
 void TrainController::printState() {
-  Serial.print("Train state: ");
-  switch (trainState) {
-    case STOPPED: Serial.println("STOPPED"); break;
-    case SLOW:    Serial.println("SLOW");    break;
-    case FAST:    Serial.println("FAST");    break;
-    default:      Serial.println("UNKNOWN"); break;
-  }
+    Serial.print("Train state: ");
+    switch (trainState) {
+        case STOPPED: Serial.println("STOPPED"); break;
+        case SLOW:        Serial.println("SLOW");        break;
+        case FAST:        Serial.println("FAST");        break;
+        default:            Serial.println("UNKNOWN"); break;
+    }
 }

--- a/src/legotraintest.ino
+++ b/src/legotraintest.ino
@@ -38,41 +38,41 @@ const int LIGHT_SENSOR_TIMEOUT_THRESHOLD = 500;
 LightSensor lightSensor(LIGHT_SENSOR_PIN, LIGHT_SENSOR_THRESHOLD);
 
 void setup() {
-  Serial.begin(115200);
+    Serial.begin(115200);
 }
 
 void loop() {
-  unsigned long currentMillis = millis();
-  unsigned long deltaT = currentMillis - previousMillis; // Time elapsed between last speed change and now.
+    unsigned long currentMillis = millis();
+    unsigned long deltaT = currentMillis - previousMillis; // Time elapsed between last speed change and now.
 
-  trainController.updateSpeedTimer();
-  inputController.handleSerialInput();
-  inputController.handleButtonInput();
+    trainController.updateSpeedTimer();
+    inputController.handleSerialInput();
+    inputController.handleButtonInput();
 
-  if (lightSensor.detectPassingTrain()) {
-    trainController.setState(SPEED::STOPPED);
-  }
+    if (lightSensor.detectPassingTrain()) {
+        trainController.setState(SPEED::STOPPED);
+    }
 
-  if (!bluetoothController.connect()) {
-    return;
-  }
+    if (!bluetoothController.connect()) {
+        return;
+    }
 
-  if (!bluetoothController.isConnected()) {
-    return;
-  }
+    if (!bluetoothController.isConnected()) {
+        return;
+    }
 
-  if (deltaT < speedSwitchInterval) { // If we haven't reached the interval to change speed we should not change the speed.
-    return;
-  }
+    if (deltaT < speedSwitchInterval) { // If we haven't reached the interval to change speed we should not change the speed.
+        return;
+    }
 
-  previousMillis = currentMillis;
+    previousMillis = currentMillis;
 
-  char hubName[] = "trainHub";
-  trainHub.setHubName(hubName);
+    char hubName[] = "trainHub";
+    trainHub.setHubName(hubName);
 
-  int speed = (int) trainController.getState();
+    int speed = (int) trainController.getState();
 
-  trainController.printState();
+    trainController.printState();
 
-  bluetoothController.setMotorSpeed(MOTOR_PORT, speed);
+    bluetoothController.setMotorSpeed(MOTOR_PORT, speed);
 }

--- a/src/legotraintest.ino
+++ b/src/legotraintest.ino
@@ -26,13 +26,13 @@ const int slowButton = D4;
 InputController inputController(&trainController, fastButton, slowButton);
 
 unsigned long previousMillis = 0;
-const long speedSwitchInterval = 200;
+const long speedSwitchInterval = 100;
 
 // ------------------------------------
 // --- Light Sensor Train Detection ---
 // ------------------------------------
 const int LIGHT_SENSOR_PIN = A0; // Analogue pin 0
-const int LIGHT_SENSOR_THRESHOLD = 500;
+const int LIGHT_SENSOR_THRESHOLD = 20; // Percentage threshold for light level detection
 const int LIGHT_SENSOR_TIMEOUT_THRESHOLD = 500;
 
 LightSensor lightSensor(LIGHT_SENSOR_PIN, LIGHT_SENSOR_THRESHOLD);


### PR DESCRIPTION
Original implementation used a fixed light level threshold for determining whether a train was passing over the sensor.

Further testing showed that this threshold did not work well in low light conditions, which are almost certainly going to be used for demonstration of the project.

These changes reimplement the light level detection to use a fixed buffer of 64 past light level readings to calculate an average light level and a percentage of that will be used to trigger the train detection.