### PR TITLE
Reverse Speed Rewrite

### DIFF
--- a/include/TrainController.hpp
+++ b/include/TrainController.hpp
@@ -19,10 +19,16 @@ private:
   unsigned long previousMillis;
   const long speedSwitchInterval;
   byte port;
-
-public:
   bool isReverse = false; // Added to track reverse state
 
+public:
+  bool setReverse(bool reverse) {
+    isReverse = reverse;
+    return isReverse;
+  }
+  bool getReverse() const {
+    return isReverse;
+  }
   TrainController(byte motorPort);
   
   void setState(SPEED newState);

--- a/include/TrainController.hpp
+++ b/include/TrainController.hpp
@@ -8,8 +8,7 @@
 enum SPEED {
   STOPPED = 0,
   FAST = 30,
-  SLOW = 15,
-  REVERSE = -30,
+  SLOW = 15
 };
 #endif // SPEED_ENUM_DEFINED
 
@@ -22,6 +21,8 @@ private:
   byte port;
 
 public:
+  bool isReverse = false; // Added to track reverse state
+
   TrainController(byte motorPort);
   
   void setState(SPEED newState);

--- a/src/InputController.cpp
+++ b/src/InputController.cpp
@@ -109,9 +109,11 @@ void InputController::handleSerialInput() {
     const int SLOW_COMMAND_LENGTH = sizeof(SLOW_COMMAND) - 1;
     const char FAST_COMMAND[] = "fast";
     const int FAST_COMMAND_LENGTH = sizeof(FAST_COMMAND) - 1;
+    const char REVERSE_COMMAND[] = "reverse";
+    const int REVERSE_COMMAND_LENGTH = sizeof(REVERSE_COMMAND) - 1;
 
-    const char* commands[] = {STOP_COMMAND, SLOW_COMMAND, FAST_COMMAND};
-    const int commandLengths[] = {STOP_COMMAND_LENGTH, SLOW_COMMAND_LENGTH, FAST_COMMAND_LENGTH};
+    const char* commands[] = {STOP_COMMAND, SLOW_COMMAND, FAST_COMMAND, REVERSE_COMMAND};
+    const int commandLengths[] = {STOP_COMMAND_LENGTH, SLOW_COMMAND_LENGTH, FAST_COMMAND_LENGTH, REVERSE_COMMAND_LENGTH};
     const SPEED states[] = {STOPPED, SLOW, FAST};
 
     const int numCommands = sizeof(commands) / sizeof(commands[0]);
@@ -122,15 +124,28 @@ void InputController::handleSerialInput() {
 
     recievedData = Serial.readStringUntil('\n');
     recievedData.trim();
+    if (recievedData.length() == 0) return; // Exit if no data received
+    recievedData.toLowerCase(); // Normalize to lowercase for command comparison
+    
+    bool commandFound = false;
 
     for (int i = 0; i < numCommands; i++) {
         if (recievedData.length() != commandLengths[i]) continue;
         if (!recievedData.equals(commands[i])) continue;
 
+        if (i == 3) { // If the command is "reverse"
+            trainController->setReverse(true);
+            commandFound = true;
+            break; // Exit after processing the command
+        }
+
         trainController->setState(states[i]);
-        return; // Exit after processing the command
+        commandFound = true;
+        break; // Exit after processing the command
     }
-    Serial.println("Unknown command. Use 'stop', 'slow', 'fast', or 'reverse'.");
+    if (!commandFound) {
+        Serial.println("Unknown command. Use 'stop', 'slow', 'fast', or 'reverse'.");
+    }
     trainController->printState(); // Print current state after command processing
     Serial.flush(); // Ensure all data is sent before returning
 }

--- a/src/InputController.cpp
+++ b/src/InputController.cpp
@@ -10,38 +10,74 @@ InputController::InputController(TrainController* controller, int forwardButtonP
 }
 
 void InputController::setForwardState(SPEED oldState) {
-    switch (oldState) {
-        case STOPPED:
-            trainController->setState(SLOW);
-            break;
-        case SLOW:
-            trainController->setState(FAST);
-            break;
-        case REVERSE:
-            trainController->setState(STOPPED);
-            break;
-        case FAST:
-            break;
-        default:
-            break;
+    if (trainController->getReverse()) {
+        // When in reverse, decrease speed until stopped, then switch to forward
+        switch (oldState) {
+            case FAST:
+                trainController->setState(SLOW);
+                break;
+            case SLOW:
+                trainController->setState(STOPPED);
+                break;
+            case STOPPED:
+                trainController->setReverse(false); // Switch to forward
+                trainController->setState(SLOW);    // Start at slow speed
+                break;
+            default:
+                trainController->setState(STOPPED);
+                break;
+        }
+    } else {
+        // When already in forward, increase speed
+        switch (oldState) {
+            case STOPPED:
+                trainController->setState(SLOW);
+                break;
+            case SLOW:
+                trainController->setState(FAST);
+                break;
+            case FAST:
+                break;
+            default:
+                trainController->setState(STOPPED);
+                break;
+        }
     }
 }
 
 void InputController::setBackwardState(SPEED oldState) {
-    switch (oldState) {
-        case STOPPED:
-            trainController->setState(REVERSE);
-            break;
-        case SLOW:
-            trainController->setState(STOPPED);
-            break;
-        case FAST:
-            trainController->setState(SLOW);
-            break;
-        case REVERSE:
-            break;
-        default:
-            break;
+    if (trainController->getReverse()) {
+        // When in reverse, increase speed
+        switch (oldState) {
+            case STOPPED:
+                trainController->setState(SLOW);
+                break;
+            case SLOW:
+                trainController->setState(FAST);
+                break;
+            case FAST:
+                break;
+            default:
+                trainController->setState(STOPPED);
+                break;
+        }
+    } else {
+        // When in forward, decrease speed until stopped, then switch to reverse
+        switch (oldState) {
+            case FAST:
+                trainController->setState(SLOW);
+                break;
+            case SLOW:
+                trainController->setState(STOPPED);
+                break;
+            case STOPPED:
+                trainController->setReverse(true); // Switch to reverse
+                trainController->setState(SLOW);   // Start at slow speed
+                break;
+            default:
+                trainController->setState(STOPPED);
+                break;
+        }
     }
 }
 
@@ -73,12 +109,10 @@ void InputController::handleSerialInput() {
     const int SLOW_COMMAND_LENGTH = sizeof(SLOW_COMMAND) - 1;
     const char FAST_COMMAND[] = "fast";
     const int FAST_COMMAND_LENGTH = sizeof(FAST_COMMAND) - 1;
-    const char REVERSE_COMMAND[] = "reverse";
-    const int REVERSE_COMMAND_LENGTH = sizeof(REVERSE_COMMAND) - 1;
 
-    const char* commands[] = {STOP_COMMAND, SLOW_COMMAND, FAST_COMMAND, REVERSE_COMMAND};
-    const int commandLengths[] = {STOP_COMMAND_LENGTH, SLOW_COMMAND_LENGTH, FAST_COMMAND_LENGTH, REVERSE_COMMAND_LENGTH};
-    const SPEED states[] = {STOPPED, SLOW, FAST, REVERSE};
+    const char* commands[] = {STOP_COMMAND, SLOW_COMMAND, FAST_COMMAND};
+    const int commandLengths[] = {STOP_COMMAND_LENGTH, SLOW_COMMAND_LENGTH, FAST_COMMAND_LENGTH};
+    const SPEED states[] = {STOPPED, SLOW, FAST};
 
     const int numCommands = sizeof(commands) / sizeof(commands[0]);
 

--- a/src/InputController.cpp
+++ b/src/InputController.cpp
@@ -126,7 +126,7 @@ void InputController::handleSerialInput() {
     recievedData.trim();
     if (recievedData.length() == 0) return; // Exit if no data received
     recievedData.toLowerCase(); // Normalize to lowercase for command comparison
-    
+
     bool commandFound = false;
 
     for (int i = 0; i < numCommands; i++) {
@@ -134,7 +134,9 @@ void InputController::handleSerialInput() {
         if (!recievedData.equals(commands[i])) continue;
 
         if (i == 3) { // If the command is "reverse"
-            trainController->setReverse(true);
+            trainController->setReverse(!trainController->getReverse()); // Toggle reverse state
+            Serial.print("Reverse state set to: ");
+            Serial.println(trainController->getReverse() ? "ON" : "OFF");
             commandFound = true;
             break; // Exit after processing the command
         }

--- a/src/TrainController.cpp
+++ b/src/TrainController.cpp
@@ -37,9 +37,10 @@ void TrainController::clearStateChanged() {
 
 // Get the speed value for a given state
 int TrainController::getSpeed(SPEED state) {
+    int reverseMultiplier = isReverse ? -1 : 1; // Adjust speed for reverse state
     switch (state) {
-        case FAST: return 30;
-        case SLOW: return 15;
+        case FAST: return 30 * reverseMultiplier;
+        case SLOW: return 15 * reverseMultiplier;
         case STOPPED: return 0;
         default: return 0;
     }
@@ -62,7 +63,6 @@ void TrainController::printState() {
         case STOPPED: Serial.println("STOPPED"); break;
         case SLOW: Serial.println("SLOW"); break;
         case FAST: Serial.println("FAST"); break;
-        case REVERSE: Serial.println("REVERSE"); break;
         default: Serial.println("UNKNOWN"); break;
     }
 }

--- a/src/legotraintest.ino
+++ b/src/legotraintest.ino
@@ -61,7 +61,8 @@ void loop() {
     char hubName[] = "trainHub";
     trainHub.setHubName(hubName);
 
-    int speed = (int) trainController.getState();
+    SPEED currentState = trainController.getState();
+    int speed = trainController.getSpeed(currentState);
 
     trainController.printState();
 


### PR DESCRIPTION
Switched to applying a speed multiplier of -1 to the existing speed states when setting the train into reverse.  This allows the train to use all of the available speed values in both reverse and forward operating.  Switched the serial _reverse_ command to toggle this value.