### PR TITLE
Reset speed multiplier when stop state applied

### DIFF
--- a/src/TrainController.cpp
+++ b/src/TrainController.cpp
@@ -19,6 +19,9 @@ void TrainController::setState(SPEED newState) {
     } else {
         stateChanged = false; // No change if the state is the same
     }
+    if (newState == STOPPED) {
+        speedMultiplier = 0; // Reset multiplier when stopped
+    }
 }
 
 // Get the current train state


### PR DESCRIPTION
Bug was discovered in testing where setting the state to stopped wouldn't reset the multiplier.  This meant that when trying to move the train again from a stop when the stop state was directly set (e.g. via a sensor) would start the train at the old multiplier, meaning it would suddenly start at a higher speed than expected.