### PR TITLE
Serial logging updated to only log speed when changes occur

### DIFF
--- a/src/legotraintest.ino
+++ b/src/legotraintest.ino
@@ -271,7 +271,9 @@ void loop() {
     SPEED currentState = trainController.getState();
     int speed = trainController.getSpeed(currentState);
 
-    trainController.printState();
+    if (trainController.hasStateChanged()) {
+        trainController.printState();
+    }
 
     bluetoothController.setMotorSpeed(MOTOR_PORT, speed);
 }


### PR DESCRIPTION
See #24 

Added a condition to only output the speed and state when it is changed.  This one change significantly reduced the number lines in the serial log, making testing much easier.