### PR TITLE
Bugfix/26 actions only triggered when position changes

### DIFF
--- a/include/Action/DelayedAction.hpp
+++ b/include/Action/DelayedAction.hpp
@@ -14,9 +14,11 @@ private:
 public:
     DelayedAction(std::unique_ptr<SensorAction> action, unsigned long delayTime);
     void execute(TrainController& controller) override;
+    void execute(TrainController& controller, ActionController& actionController) override;
     std::unique_ptr<SensorAction> clone() const override;
     bool isDelayedAction() const override { return true; } // Identify as DelayedAction
     bool update(TrainController& controller); // Non-blocking update method
+    bool update(TrainController& controller, ActionController& actionController); // Non-blocking update with ActionController
     bool isFinished() const;
     void reset();
     

--- a/include/Action/ReverseAction.hpp
+++ b/include/Action/ReverseAction.hpp
@@ -4,6 +4,9 @@
 #include "TrainController.hpp"
 #include <memory>
 
+// Forward declarations
+class ActionController;
+
 class ReverseAction : public SensorAction {
 private:
     int delayMs;
@@ -11,6 +14,7 @@ public:
     explicit ReverseAction(int delay = 0);
     
     void execute(TrainController& controller) override;
+    void execute(TrainController& controller, ActionController& actionController) override;
     std::unique_ptr<SensorAction> clone() const override;
 };
 #endif // REVERSE_ACTION_HPP

--- a/include/PositionSensorController.hpp
+++ b/include/PositionSensorController.hpp
@@ -22,6 +22,9 @@ public:
     // Check all position actions and execute if conditions are met
     void checkAndExecuteActions(TrainController& trainController, ActionController& actionController);
     
+    // Access to position tracker
+    PositionTracker* getPositionTracker() { return &positionTracker; }
+    
     // Reset all position actions (useful when starting a new loop)
     void resetAllActions();
     

--- a/include/PositionTracker.hpp
+++ b/include/PositionTracker.hpp
@@ -35,6 +35,7 @@ public:
     SensorLocation getCurrentPosition() const { return currentPosition; }
     SensorLocation getPreviousPosition() const { return previousPosition; }
     TrainDirection getDirection() const { return currentDirection; }
+    void setDirection(TrainDirection direction) { currentDirection = direction; }
     
     void addTrackSegment(const TrackSegment& segment);
     std::vector<std::unique_ptr<SensorAction>> getActionsForPosition(SensorLocation position, TrainDirection direction);

--- a/include/ReedSwitchSensor.hpp
+++ b/include/ReedSwitchSensor.hpp
@@ -31,6 +31,7 @@ public:
     void reset() override; // Reset the sensor state
     void executeAction(TrainController& controller, ActionController& actionController) override; // Execute the associated action
     SensorLocation getLocation() const;
+    int getPin() const { return pin; } // Get the pin number for debugging
 };
 
 #endif // REEDSWITCHSENSOR_HPP

--- a/platformio.ini
+++ b/platformio.ini
@@ -12,6 +12,7 @@
 platform = espressif32
 board = arduino_nano_esp32
 framework = arduino
+upload_protocol = esptool
 build_flags =
 	-D ARDUINO_NANO_ESP32
 	-D ARDUINO_ARCH_ESP32

--- a/src/Action/DelayedAction.cpp
+++ b/src/Action/DelayedAction.cpp
@@ -1,6 +1,7 @@
 #include <Arduino.h>
 #include "Action/DelayedAction.hpp"
 #include "TrainController.hpp"
+#include "ActionController.hpp"
 
 /**
  * Constructor for DelayedAction.
@@ -35,6 +36,28 @@ void DelayedAction::execute(TrainController& controller) {
 }
 
 /**
+ * Executes the delayed action on the train controller with ActionController (blocking version).
+ * DEPRECATED: Use update() for non-blocking execution.
+ * @param controller The train controller to operate on.
+ * @param actionController The action controller for managing complex actions.
+ */
+[[deprecated("Use update() for non-blocking execution")]]
+void DelayedAction::execute(TrainController& controller, ActionController& actionController) {
+    // Start the timer and mark as active
+    startTime = millis();
+    isActive = true;
+    isCompleted = false;
+
+    Serial.println("Using deprecated execute method for DelayedAction with ActionController");
+    
+    // Block until delay is complete, then execute
+    while (!update(controller, actionController)) {
+        // Small delay to prevent busy waiting
+        delay(1);
+    }
+}
+
+/**
  * Non-blocking update method.
  * @param controller The train controller to operate on.
  * @return true if the action has completed, false if still waiting
@@ -56,6 +79,37 @@ bool DelayedAction::update(TrainController& controller) {
         // Execute the action
         if (action) {
             action->execute(controller);
+        }
+        isCompleted = true;
+        return true;
+    }
+    
+    return false; // Still waiting
+}
+
+/**
+ * Non-blocking update method with ActionController.
+ * @param controller The train controller to operate on.
+ * @param actionController The action controller for managing complex actions.
+ * @return true if the action has completed, false if still waiting
+ */
+bool DelayedAction::update(TrainController& controller, ActionController& actionController) {
+    if (isCompleted) {
+        return true;
+    }
+    
+    if (!isActive) {
+        // Start the timer
+        startTime = millis();
+        isActive = true;
+        return false;
+    }
+    
+    // Check if delay time has elapsed
+    if (millis() - startTime >= delayTime) {
+        // Execute the action with ActionController
+        if (action) {
+            action->execute(controller, actionController);
         }
         isCompleted = true;
         return true;

--- a/src/Action/ReverseAction.cpp
+++ b/src/Action/ReverseAction.cpp
@@ -1,5 +1,9 @@
 #include "Action/ReverseAction.hpp"
+#include "ActionController.hpp"
+#include "PositionTracker.hpp"
+#include "PositionSensorController.hpp"
 #include <memory>
+#include <Arduino.h>
 
 ReverseAction::ReverseAction(int delay)
     : delayMs(delay) {}
@@ -11,6 +15,35 @@ void ReverseAction::execute(TrainController& controller) {
     
     // Don't automatically start the train if it's stopped
     // Let other actions control the speed
+    
+    // Optional delay after reversing
+    if (delayMs > 0) {
+        delay(delayMs);
+    }
+}
+
+void ReverseAction::execute(TrainController& controller, ActionController& actionController) {
+    // Toggle the reverse state in TrainController
+    bool currentReverse = controller.getReverse();
+    controller.setReverse(!currentReverse);
+    
+    // Also update the PositionTracker direction if available
+    if (actionController.getPositionController()) {
+        PositionTracker* positionTracker = actionController.getPositionController()->getPositionTracker();
+        if (positionTracker) {
+            // Toggle the direction in PositionTracker as well
+            TrainDirection currentDirection = positionTracker->getDirection();
+            TrainDirection newDirection = (currentDirection == TrainDirection::FORWARD) ? 
+                                        TrainDirection::REVERSE : TrainDirection::FORWARD;
+            positionTracker->setDirection(newDirection);
+            
+            Serial.print("ReverseAction: Updated both TrainController reverse (");
+            Serial.print(!currentReverse ? "ON" : "OFF");
+            Serial.print(") and PositionTracker direction (");
+            Serial.print(newDirection == TrainDirection::FORWARD ? "FORWARD" : "REVERSE");
+            Serial.println(")");
+        }
+    }
     
     // Optional delay after reversing
     if (delayMs > 0) {

--- a/src/Action/SequentialAction.cpp
+++ b/src/Action/SequentialAction.cpp
@@ -94,7 +94,7 @@ bool SequentialAction::update(TrainController& controller, ActionController& act
 
         if (!action->isDelayedAction()) {
             // Execute immediate action and move to next
-            action->execute(controller);
+            action->execute(controller, actionController);
             currentActionIndex++;
             continue;
         }
@@ -106,7 +106,7 @@ bool SequentialAction::update(TrainController& controller, ActionController& act
         }
 
         // Update the delayed action
-        if (!currentDelayedAction->update(controller)) {
+        if (!currentDelayedAction->update(controller, actionController)) {
             // Still waiting for delayed action to complete
             return false;
         }

--- a/src/ActionController.cpp
+++ b/src/ActionController.cpp
@@ -73,7 +73,7 @@ void ActionController::update() {
     activeDelayedActions.erase(
         std::remove_if(activeDelayedActions.begin(), activeDelayedActions.end(),
             [this](std::unique_ptr<DelayedAction>& action) {
-                return action->update(*trainController);
+                return action->update(*trainController, *this);
             }),
         activeDelayedActions.end()
     );

--- a/src/PositionAwareSensorController.cpp
+++ b/src/PositionAwareSensorController.cpp
@@ -32,20 +32,18 @@ bool PositionAwareSensorController::checkSensorsAndUpdatePosition() {
     if (sensorTriggered && newLocation != SensorLocation::UNKNOWN && 
         (currentTime - lastTriggerTime) > DEBOUNCE_TIME) {
         
-        // Only update if the location actually changed
-        if (newLocation != lastTriggeredLocation) {
-            lastTriggeredLocation = newLocation;
-            lastTriggerTime = currentTime;
-            
-            // Update the position tracker
-            if (positionTracker) {
-                positionTracker->updatePosition(newLocation);
-            }
-            
-            Serial.print("Position updated to: ");
-            Serial.println(static_cast<int>(newLocation));
-            return true;
+        // Always update the position tracker - let it decide how to handle repeated positions
+        lastTriggeredLocation = newLocation;
+        lastTriggerTime = currentTime;
+        
+        // Update the position tracker
+        if (positionTracker) {
+            positionTracker->updatePosition(newLocation);
         }
+        
+        Serial.print("Sensor trigger processed for location: ");
+        Serial.println(static_cast<int>(newLocation));
+        return true;
     }
     
     return false;

--- a/src/PositionTracker.cpp
+++ b/src/PositionTracker.cpp
@@ -7,7 +7,12 @@ PositionTracker::PositionTracker(SensorLocation startPosition)
 
 void PositionTracker::updatePosition(SensorLocation newPosition) {
     if (newPosition == currentPosition) {
-        // No change in position
+        // Same position triggered again - this often happens when reversing over the same sensor
+        // Don't update direction based on sensor movement in this case, trust the current direction
+        Serial.print("Same sensor triggered again at position: ");
+        Serial.print(static_cast<int>(currentPosition));
+        Serial.print(", keeping current direction: ");
+        Serial.println(currentDirection == TrainDirection::FORWARD ? "FORWARD" : "REVERSE");
         return;
     }
     

--- a/src/legotraintest.ino
+++ b/src/legotraintest.ino
@@ -66,10 +66,11 @@ void setupTrackLayout() {
     // WEST_STATION
     TrackSegment westStation;
     westStation.location = SensorLocation::WEST_STATION;
-    westStation.forwardActions.push_back(std::unique_ptr<SpeedAction>(new SpeedAction(2, 0)));
+    westStation.forwardActions.push_back(std::unique_ptr<SpeedAction>(new SpeedAction(0, 0)));
     // Sequential action for reverse direction: STOP (delay) -> REVERSE (delay) -> SPEED
     {
         std::vector<std::unique_ptr<SensorAction>> reverseActions;
+        reverseActions.push_back(std::unique_ptr<SensorAction>(new SpeedAction(-1, 0)));
         reverseActions.push_back(std::unique_ptr<SensorAction>(new DelayedAction(
             std::unique_ptr<SensorAction>(new StopAction(0)), 500
         )));
@@ -97,8 +98,8 @@ void setupTrackLayout() {
         forwardActions.push_back(std::unique_ptr<SensorAction>(new SpeedAction(2, 0)));
         westTunnel.forwardActions.push_back(std::unique_ptr<SequentialAction>(new SequentialAction(std::move(forwardActions))));
     }
-    
-    westTunnel.reverseActions.push_back(std::unique_ptr<SpeedAction>(new SpeedAction(0, 0)));
+
+    westTunnel.reverseActions.push_back(std::unique_ptr<SpeedAction>(new SpeedAction(1, 0)));
 
     westTunnel.nextForward = SensorLocation::WEST_TUNNEL;
     westTunnel.nextReverse = SensorLocation::WEST_STATION;
@@ -186,6 +187,20 @@ void setup() {
 void loop() {
     unsigned long currentMillis = millis();
     unsigned long deltaT = currentMillis - previousMillis; // Time elapsed between last speed change and now.
+
+    // Debug: Periodically check raw pin states
+    static unsigned long lastPinCheck = 0;
+    if (currentMillis - lastPinCheck > 5000) { // Every 5 seconds
+        Serial.print("PIN STATE CHECK - D12: ");
+        Serial.print(digitalRead(D12) == LOW ? "ACTIVE" : "INACTIVE");
+        Serial.print(", D11: ");
+        Serial.print(digitalRead(D11) == LOW ? "ACTIVE" : "INACTIVE");
+        Serial.print(", D10: ");
+        Serial.print(digitalRead(D10) == LOW ? "ACTIVE" : "INACTIVE");
+        Serial.print(", D9: ");
+        Serial.println(digitalRead(D9) == LOW ? "ACTIVE" : "INACTIVE");
+        lastPinCheck = currentMillis;
+    }
 
     trainController.updateSpeedTimer();
     inputController.handleSerialInput();

--- a/src/legotraintest.ino
+++ b/src/legotraintest.ino
@@ -98,9 +98,9 @@ void setupTrackLayout() {
         westTunnel.forwardActions.push_back(std::unique_ptr<SequentialAction>(new SequentialAction(std::move(forwardActions))));
     }
     
-    westTunnel.reverseActions.push_back(std::unique_ptr<SpeedAction>(new SpeedAction(2, 0)));
+    westTunnel.reverseActions.push_back(std::unique_ptr<SpeedAction>(new SpeedAction(0, 0)));
 
-    westTunnel.nextForward = SensorLocation::EAST_TUNNEL;
+    westTunnel.nextForward = SensorLocation::WEST_TUNNEL;
     westTunnel.nextReverse = SensorLocation::WEST_STATION;
     positionTracker.addTrackSegment(westTunnel);
 
@@ -111,8 +111,10 @@ void printCurrentPosition() {
     Serial.print(getPositionName(positionTracker.getCurrentPosition()));
     Serial.print(" (Previous: ");
     Serial.print(getPositionName(positionTracker.getPreviousPosition()));
-    Serial.print(", Direction: ");
+    Serial.print(", PositionTracker Direction: ");
     Serial.print(positionTracker.getDirection() == TrainDirection::FORWARD ? "FORWARD" : "REVERSE");
+    Serial.print(", TrainController Reverse: ");
+    Serial.print(trainController.getReverse() ? "ON" : "OFF");
     Serial.println(")");
 }
 
@@ -153,6 +155,28 @@ void setup() {
     // Connect the position-based controller to the action controller
     actionController.setPositionController(&positionSensorController);
     Serial.println("Position-based action system enabled");
+    
+    // Synchronize direction between TrainController and PositionTracker at startup
+    TrainDirection positionTrackerDirection = positionTracker.getDirection();
+    bool trainControllerReverse = trainController.getReverse();
+    
+    // Convert PositionTracker direction to TrainController reverse boolean
+    // FORWARD = false (not reverse), REVERSE = true (reverse)
+    bool expectedReverse = (positionTrackerDirection == TrainDirection::REVERSE);
+    
+    if (trainControllerReverse != expectedReverse) {
+        Serial.print("Synchronizing directions at startup: TrainController was ");
+        Serial.print(trainControllerReverse ? "REVERSE" : "FORWARD");
+        Serial.print(", PositionTracker was ");
+        Serial.print(positionTrackerDirection == TrainDirection::FORWARD ? "FORWARD" : "REVERSE");
+        
+        trainController.setReverse(expectedReverse);
+        Serial.print(" -> Both now set to ");
+        Serial.println(expectedReverse ? "REVERSE" : "FORWARD");
+    } else {
+        Serial.print("Directions already synchronized: ");
+        Serial.println(expectedReverse ? "REVERSE" : "FORWARD");
+    }
     
     Serial.println("Position tracking system initialized");
     Serial.print("Starting position: ");


### PR DESCRIPTION
See #26.

The old sensor system would only perform an action where the train moves from one sensor to another.  This change allows for the train to move over the same sensor again and have it trigger actions regardless.