### PR TITLE
Bugfix - Only one sensor is triggered in an update

### DIFF
--- a/include/PositionAwareSensorController.hpp
+++ b/include/PositionAwareSensorController.hpp
@@ -21,7 +21,7 @@ public:
     bool checkSensors();
     
     // Get the sensor that was triggered (for executing actions)
-    Sensor* getTriggeredSensor() const;
+    std::vector<Sensor*> getTriggeredSensor() const;
     
     // Get triggered location
     SensorLocation getTriggeredLocation() const { return lastTriggeredLocation; }

--- a/include/ReedSwitchSensorController.hpp
+++ b/include/ReedSwitchSensorController.hpp
@@ -7,7 +7,7 @@ class ReedSwitchSensorController {
 private:
     ReedSwitchSensor* sensors[MAX_SENSORS]; // Array of ReedSwitchSensor pointers
     int sensorCount;
-    ReedSwitchSensor* lastTriggeredSensor;
+    std::vector<ReedSwitchSensor*> lastTriggeredSensors;
 
 public:
     ReedSwitchSensorController();
@@ -18,6 +18,6 @@ public:
 
     void addSensor(ReedSwitchSensor* sensor);
 
-    ReedSwitchSensor* getTriggeredSensor() const;
+    std::vector<ReedSwitchSensor*> getTriggeredSensors() const;
 };
 #endif // REEDSWITCHSENSORCONTROLLER_HPP

--- a/include/Sensor.hpp
+++ b/include/Sensor.hpp
@@ -14,6 +14,7 @@ public:
     virtual bool isTrainDetected() const = 0;
     virtual void reset() = 0;
     virtual void executeAction(TrainController& controller, ActionController& actionController) = 0;
+    virtual SensorLocation getLocation() const = 0;
 };
 
 #endif // SENSOR_HPP

--- a/src/PositionAwareSensorController.cpp
+++ b/src/PositionAwareSensorController.cpp
@@ -9,48 +9,52 @@ PositionAwareSensorController::PositionAwareSensorController(ReedSwitchSensorCon
 
 bool PositionAwareSensorController::checkSensors() {
     unsigned long currentTime = millis();
-    SensorLocation newLocation = SensorLocation::UNKNOWN;
+
+    if (currentTime - lastTriggerTime > DEBOUNCE_TIME) {
+        return false;
+    }
+
     bool sensorTriggered = false;
     
-    // Check reed switch sensors first (they're more reliable)
-    if (reedSwitchController && reedSwitchController->isTrainPassingOver()) {
-        newLocation = reedSwitchController->getTriggeredSensorLocation();
+    std::vector<Sensor*> triggeredSensors = getTriggeredSensor();
+
+    for (Sensor* sensor : triggeredSensors) {
+        if (!sensor) continue;
         sensorTriggered = true;
-        Serial.print("Reed switch triggered at location: ");
-        Serial.println(static_cast<int>(newLocation));
+        Serial.print("Sensor triggered at location: ");
+        Serial.println(static_cast<int>(sensor->getLocation()));
     }
-    // Check light sensors as backup
-    else if (lightSensorController && lightSensorController->isTrainPassingOver()) {
-        newLocation = lightSensorController->getTriggeredSensorLocation();
-        sensorTriggered = true;
-        Serial.print("Light sensor triggered at location: ");
-        Serial.println(static_cast<int>(newLocation));
-    }
-    
-    // Update location if a sensor was triggered and enough time has passed (debounce)
-    if (sensorTriggered && newLocation != SensorLocation::UNKNOWN && 
-        (currentTime - lastTriggerTime) > DEBOUNCE_TIME) {
-        
-        lastTriggeredLocation = newLocation;
+
+    for (const Sensor* sensor : triggeredSensors) {
+        if (!sensor) continue;
+        SensorLocation loc = sensor->getLocation();
+        if (loc != SensorLocation::UNKNOWN) {
+            lastTriggeredLocation = loc;
+        }
+        lastTriggeredLocation = loc;
         lastTriggerTime = currentTime;
-        
-        Serial.print("Sensor trigger processed for location: ");
-        Serial.println(static_cast<int>(newLocation));
-        return true;
     }
-    
-    return false;
+
+    return sensorTriggered;
 }
 
-Sensor* PositionAwareSensorController::getTriggeredSensor() const {
-    // Return the most recently triggered sensor
-    if (reedSwitchController && reedSwitchController->getTriggeredSensor()) {
-        return reedSwitchController->getTriggeredSensor();
+std::vector<Sensor*> PositionAwareSensorController::getTriggeredSensor() const {
+    std::vector<Sensor*> triggeredSensors;
+    
+    // Add triggered reed switch sensors
+    if (reedSwitchController && reedSwitchController->getTriggeredSensors().size() > 0) {
+        const auto& reedSensors = reedSwitchController->getTriggeredSensors();
+        for (ReedSwitchSensor* reedSensor : reedSensors) {
+            triggeredSensors.push_back(static_cast<Sensor*>(reedSensor));
+        }
     }
+    
+    // Add triggered light sensor if any
     if (lightSensorController && lightSensorController->getTriggeredSensor()) {
-        return lightSensorController->getTriggeredSensor();
+        triggeredSensors.push_back(static_cast<Sensor*>(lightSensorController->getTriggeredSensor()));
     }
-    return nullptr;
+    
+    return triggeredSensors;
 }
 
 bool PositionAwareSensorController::isTrainDetected() const {

--- a/src/PositionAwareSensorController.cpp
+++ b/src/PositionAwareSensorController.cpp
@@ -10,20 +10,29 @@ PositionAwareSensorController::PositionAwareSensorController(ReedSwitchSensorCon
 bool PositionAwareSensorController::checkSensors() {
     unsigned long currentTime = millis();
 
-    if (currentTime - lastTriggerTime > DEBOUNCE_TIME) {
+    if (currentTime - lastTriggerTime <= DEBOUNCE_TIME) {
         return false;
     }
 
     bool sensorTriggered = false;
     
-    std::vector<Sensor*> triggeredSensors = getTriggeredSensor();
-
-    for (Sensor* sensor : triggeredSensors) {
-        if (!sensor) continue;
-        sensorTriggered = true;
-        Serial.print("Sensor triggered at location: ");
-        Serial.println(static_cast<int>(sensor->getLocation()));
+    // Check sensors and update triggered sensors lists
+    if (reedSwitchController) {
+        bool reedTriggered = reedSwitchController->isTrainPassingOver();
+        if (reedTriggered) {
+            sensorTriggered = true;
+        }
     }
+    
+    if (lightSensorController) {
+        bool lightTriggered = lightSensorController->isTrainPassingOver();
+        if (lightTriggered) {
+            sensorTriggered = true;
+        }
+    }
+    
+    // Now get the triggered sensors for location tracking
+    std::vector<Sensor*> triggeredSensors = getTriggeredSensor();
 
     for (const Sensor* sensor : triggeredSensors) {
         if (!sensor) continue;
@@ -41,17 +50,20 @@ bool PositionAwareSensorController::checkSensors() {
 std::vector<Sensor*> PositionAwareSensorController::getTriggeredSensor() const {
     std::vector<Sensor*> triggeredSensors;
     
-    // Add triggered reed switch sensors
-    if (reedSwitchController && reedSwitchController->getTriggeredSensors().size() > 0) {
+    if (reedSwitchController) {
         const auto& reedSensors = reedSwitchController->getTriggeredSensors();
-        for (ReedSwitchSensor* reedSensor : reedSensors) {
-            triggeredSensors.push_back(static_cast<Sensor*>(reedSensor));
+        if (reedSensors.size() > 0) {
+            for (ReedSwitchSensor* reedSensor : reedSensors) {
+                triggeredSensors.push_back(static_cast<Sensor*>(reedSensor));
+            }
         }
     }
     
-    // Add triggered light sensor if any
-    if (lightSensorController && lightSensorController->getTriggeredSensor()) {
-        triggeredSensors.push_back(static_cast<Sensor*>(lightSensorController->getTriggeredSensor()));
+    // Add triggered light sensor if any - no need to call isTrainPassingOver() again as it was already called in checkSensors()
+    if (lightSensorController) {
+        if (lightSensorController->getTriggeredSensor()) {
+            triggeredSensors.push_back(static_cast<Sensor*>(lightSensorController->getTriggeredSensor()));
+        }
     }
     
     return triggeredSensors;

--- a/src/ReedSwitchSensorController.cpp
+++ b/src/ReedSwitchSensorController.cpp
@@ -19,21 +19,24 @@ void ReedSwitchSensorController::addSensor(ReedSwitchSensor* sensor) {
 }
 
 bool ReedSwitchSensorController::isTrainPassingOver() {
+    lastTriggeredSensors.clear();
+    bool anyTriggered = false;
+
     for (int i = 0; i < sensorCount; i++) {
-            if (sensors[i] && sensors[i]->detectPassingTrain()) {
-                lastTriggeredSensor = sensors[i];
-                return true;
-            }
+        if (sensors[i] && sensors[i]->detectPassingTrain()) {
+            lastTriggeredSensors.push_back(sensors[i]);
+            anyTriggered = true;
         }
-        return false;
+    }
+    return anyTriggered;
 }
 
 // Returns the location of the last triggered sensor, or a default value if none was triggered
 SensorLocation ReedSwitchSensorController::getTriggeredSensorLocation() const {
-    ReedSwitchSensor* sensor = lastTriggeredSensor;
+    ReedSwitchSensor* sensor = lastTriggeredSensors[0];
     return sensor ? sensor->getLocation() : SensorLocation::UNKNOWN;
 }
 
-ReedSwitchSensor* ReedSwitchSensorController::getTriggeredSensor() const {
-    return lastTriggeredSensor;
+std::vector<ReedSwitchSensor*> ReedSwitchSensorController::getTriggeredSensors() const {
+    return lastTriggeredSensors;
 }

--- a/src/Train/TrainManager.cpp
+++ b/src/Train/TrainManager.cpp
@@ -207,14 +207,17 @@ void TrainManager::handlePositionUpdate() {
     
     // Check for sensor triggers
     bool sensorTriggered = positionAwareSensorController->checkSensors();
-    
+
     if (!sensorTriggered) return;
 
     std::vector<Sensor*> triggeredSensors = positionAwareSensorController->getTriggeredSensor();
 
+    Serial.println("Triggered sensors: ");
     for (Sensor* sensor : triggeredSensors) {
         if (!sensor) continue;
         SensorLocation loc = sensor->getLocation();
+        Serial.print("Sensor triggered at ");
+        Serial.println(static_cast<int>(loc));
         if (loc != SensorLocation::UNKNOWN) {
             // Find the train that should respond to this sensor trigger
             selectBestTrainForPosition(loc);

--- a/src/Train/TrainManager.cpp
+++ b/src/Train/TrainManager.cpp
@@ -208,12 +208,16 @@ void TrainManager::handlePositionUpdate() {
     // Check for sensor triggers
     bool sensorTriggered = positionAwareSensorController->checkSensors();
     
-    if (sensorTriggered) {
-        SensorLocation triggeredLocation = positionAwareSensorController->getTriggeredLocation();
-        
-        if (triggeredLocation != SensorLocation::UNKNOWN) {
+    if (!sensorTriggered) return;
+
+    std::vector<Sensor*> triggeredSensors = positionAwareSensorController->getTriggeredSensor();
+
+    for (Sensor* sensor : triggeredSensors) {
+        if (!sensor) continue;
+        SensorLocation loc = sensor->getLocation();
+        if (loc != SensorLocation::UNKNOWN) {
             // Find the train that should respond to this sensor trigger
-            selectBestTrainForPosition(triggeredLocation);
+            selectBestTrainForPosition(loc);
         }
     }
 }


### PR DESCRIPTION
See #30.

The old system, being designed for one train only, could only process one sensor trigger in each update loop.  This meant that if two sensors were triggered in the same loop and were not triggered in the next loop, the input would be ignored.

The fix was to refactor the PositionAwareSensorController to handle many sensors at the same time, along with changes to the dependencies of this class to deal with multiple sensors.