### PR TITLE
Implemented the NonBlockingAction interface

### DIFF
--- a/include/Action/DelayedAction.hpp
+++ b/include/Action/DelayedAction.hpp
@@ -2,9 +2,10 @@
 #define DELAYED_ACTION_HPP
 
 #include "SensorAction.hpp"
+#include "NonBlockingAction.hpp"
 #include <memory>
 
-class DelayedAction : public SensorAction {
+class DelayedAction : public SensorAction, public NonBlockingAction {
 private:
     std::unique_ptr<SensorAction> action; // Pointer to the action to be executed after delay
     unsigned long delayTime;
@@ -17,10 +18,15 @@ public:
     void execute(TrainController& controller, ActionController& actionController) override;
     std::unique_ptr<SensorAction> clone() const override;
     bool isDelayedAction() const override { return true; } // Identify as DelayedAction
+    bool isNonBlockingAction() const override { return true; } // Identify as NonBlockingAction
+    
+    // NonBlockingAction interface implementation
+    bool update(TrainController& controller, ActionController& actionController) override; // Non-blocking update with ActionController
+    bool isFinished() const override;
+    void reset() override;
+    
+    // Legacy non-blocking update method (deprecated, use NonBlockingAction interface instead)
     bool update(TrainController& controller); // Non-blocking update method
-    bool update(TrainController& controller, ActionController& actionController); // Non-blocking update with ActionController
-    bool isFinished() const;
-    void reset();
     
     // Method to create a new DelayedAction instance with the same parameters
     std::unique_ptr<DelayedAction> createFresh() const;

--- a/include/Action/DelayedAction.hpp
+++ b/include/Action/DelayedAction.hpp
@@ -20,6 +20,9 @@ public:
     bool isDelayedAction() const override { return true; } // Identify as DelayedAction
     bool isNonBlockingAction() const override { return true; } // Identify as NonBlockingAction
     
+    // Helper method to get NonBlockingAction interface without RTTI
+    NonBlockingAction* asNonBlockingAction() override { return this; }
+    
     // NonBlockingAction interface implementation
     bool update(TrainController& controller, ActionController& actionController) override; // Non-blocking update with ActionController
     bool isFinished() const override;

--- a/include/Action/NonBlockingAction.hpp
+++ b/include/Action/NonBlockingAction.hpp
@@ -1,0 +1,45 @@
+#ifndef NON_BLOCKING_ACTION_HPP
+#define NON_BLOCKING_ACTION_HPP
+
+#include "TrainController.hpp"
+
+// Forward declaration to avoid circular dependency
+class ActionController;
+
+/**
+ * Interface for actions that support non-blocking execution.
+ * Actions implementing this interface can be executed over multiple update cycles
+ * without blocking the main execution thread.
+ */
+class NonBlockingAction {
+public:
+    virtual ~NonBlockingAction() = default;
+    
+    /**
+     * Non-blocking update method that should be called repeatedly until the action completes.
+     * @param controller The train controller to operate on.
+     * @param actionController The action controller for managing actions.
+     * @return true if the action has completed, false if it's still executing.
+     */
+    virtual bool update(TrainController& controller, ActionController& actionController) = 0;
+    
+    /**
+     * Check if the action has finished executing.
+     * @return true if the action has completed, false if it's still executing.
+     */
+    virtual bool isFinished() const = 0;
+    
+    /**
+     * Reset the action to its initial state so it can be executed again.
+     */
+    virtual void reset() = 0;
+    
+    /**
+     * Check if the action is a non-blocking action.
+     * This method provides a way to identify non-blocking actions without dynamic casting.
+     * @return true always, since this is a non-blocking action interface.
+     */
+    virtual bool isNonBlockingAction() const { return true; }
+};
+
+#endif // NON_BLOCKING_ACTION_HPP

--- a/include/Action/SensorAction.hpp
+++ b/include/Action/SensorAction.hpp
@@ -23,5 +23,6 @@ public:
     virtual bool isDelayedAction() const { return false; } // Override in DelayedAction
     virtual bool isSequentialAction() const { return false; } // Override in SequentialAction
     virtual bool isWaitForPositionAction() const { return false; } // Override in WaitForPositionAction
+    virtual bool isNonBlockingAction() const { return false; } // Override in NonBlockingAction implementations
 };
 #endif // SENSOR_ACTION_HPP

--- a/include/Action/SensorAction.hpp
+++ b/include/Action/SensorAction.hpp
@@ -5,6 +5,7 @@
 
 // Forward declaration to avoid circular dependency
 class ActionController;
+class NonBlockingAction;
 
 enum class SensorLocation {
     WEST_STATION,
@@ -24,5 +25,8 @@ public:
     virtual bool isSequentialAction() const { return false; } // Override in SequentialAction
     virtual bool isWaitForPositionAction() const { return false; } // Override in WaitForPositionAction
     virtual bool isNonBlockingAction() const { return false; } // Override in NonBlockingAction implementations
+    
+    // Helper method to get NonBlockingAction interface without RTTI
+    virtual NonBlockingAction* asNonBlockingAction() { return nullptr; } // Override in classes that implement NonBlockingAction
 };
 #endif // SENSOR_ACTION_HPP

--- a/include/Action/SequentialAction.hpp
+++ b/include/Action/SequentialAction.hpp
@@ -2,6 +2,7 @@
 #define SEQUENTIALACTION_HPP
 
 #include "Action/SensorAction.hpp"
+#include "Action/NonBlockingAction.hpp"
 #include "Action/DelayedAction.hpp"
 #include <vector>
 #include <memory>
@@ -9,13 +10,13 @@
 // Forward declaration
 class ActionController;
 
-class SequentialAction : public SensorAction {
+class SequentialAction : public SensorAction, public NonBlockingAction {
 private:
     std::vector<std::unique_ptr<SensorAction>> actions;
     
     // State management for non-blocking execution
     size_t currentActionIndex;
-    std::unique_ptr<DelayedAction> currentDelayedAction;
+    NonBlockingAction* currentNonBlockingAction; // Changed from DelayedAction to NonBlockingAction
     bool isExecuting;
     
 public:
@@ -23,6 +24,7 @@ public:
     SequentialAction(std::vector<std::unique_ptr<SensorAction>>&& actionList) {
         actions = std::move(actionList);
         currentActionIndex = 0;
+        currentNonBlockingAction = nullptr;
         isExecuting = false;
     }
     void addAction(std::unique_ptr<SensorAction> action);
@@ -30,11 +32,14 @@ public:
     void execute(TrainController& controller, ActionController& actionController) override;
     std::unique_ptr<SensorAction> clone() const override;
     bool isSequentialAction() const override { return true; } // Identify as SequentialAction
+    bool isNonBlockingAction() const override { return true; } // Identify as NonBlockingAction
     
-    // Non-blocking execution methods
-    bool update(TrainController& controller, ActionController& actionController);
-    void reset();
-    bool isFinished() const;
+    // NonBlockingAction interface implementation
+    bool update(TrainController& controller, ActionController& actionController) override;
+    bool isFinished() const override;
+    void reset() override;
+    
+    // Legacy methods for backward compatibility
     bool isActive() const { return isExecuting; }
 
     std::unique_ptr<SequentialAction> createFresh() const;

--- a/include/Action/SequentialAction.hpp
+++ b/include/Action/SequentialAction.hpp
@@ -34,6 +34,9 @@ public:
     bool isSequentialAction() const override { return true; } // Identify as SequentialAction
     bool isNonBlockingAction() const override { return true; } // Identify as NonBlockingAction
     
+    // Helper method to get NonBlockingAction interface without RTTI
+    NonBlockingAction* asNonBlockingAction() override { return this; }
+    
     // NonBlockingAction interface implementation
     bool update(TrainController& controller, ActionController& actionController) override;
     bool isFinished() const override;

--- a/include/Action/WaitForPositionAction.hpp
+++ b/include/Action/WaitForPositionAction.hpp
@@ -1,9 +1,10 @@
 #ifndef WAITFORPOSITIONACTION_HPP
 #define WAITFORPOSITIONACTION_HPP
 #include "Action/SensorAction.hpp"
+#include "Action/NonBlockingAction.hpp"
 #include "Train/TrainInstance.hpp"
 
-class WaitForPositionAction : public SensorAction {
+class WaitForPositionAction : public SensorAction, public NonBlockingAction {
 private:
     SensorLocation targetLocation;
     TrainInstance* trainInstance;
@@ -20,17 +21,21 @@ public:
     [[deprecated("Use update() for non-blocking execution")]]
     void execute(TrainController& controller, ActionController& actionController) override;
     
-    // Non-blocking execution methods
-    bool update(TrainController& controller);
-    bool update(TrainController& controller, ActionController& actionController);
-    
     // SensorAction interface
     std::unique_ptr<SensorAction> clone() const override;
     virtual bool isWaitForPositionAction() const { return true; } // Identify as WaitForPositionAction
+    bool isNonBlockingAction() const override { return true; } // Identify as NonBlockingAction
+    
+    // NonBlockingAction interface implementation
+    bool update(TrainController& controller, ActionController& actionController) override;
+    bool isFinished() const override;
+    void reset() override;
+    
+    // Legacy non-blocking execution method (deprecated, use NonBlockingAction interface instead)
+    bool update(TrainController& controller);
     
     // State management
-    bool isFinished() const;
-    void reset();
+    // (isFinished() and reset() methods now inherited from NonBlockingAction interface)
     
     // Factory method for creating fresh instances
     std::unique_ptr<WaitForPositionAction> createFresh() const;

--- a/include/Action/WaitForPositionAction.hpp
+++ b/include/Action/WaitForPositionAction.hpp
@@ -26,6 +26,9 @@ public:
     virtual bool isWaitForPositionAction() const { return true; } // Identify as WaitForPositionAction
     bool isNonBlockingAction() const override { return true; } // Identify as NonBlockingAction
     
+    // Helper method to get NonBlockingAction interface without RTTI
+    NonBlockingAction* asNonBlockingAction() override { return this; }
+    
     // NonBlockingAction interface implementation
     bool update(TrainController& controller, ActionController& actionController) override;
     bool isFinished() const override;

--- a/src/Action/SequentialAction.cpp
+++ b/src/Action/SequentialAction.cpp
@@ -1,6 +1,7 @@
 #include "Action/SequentialAction.hpp"
 #include "Action/DelayedAction.hpp"
 #include "Action/WaitForPositionAction.hpp"
+#include "Action/NonBlockingAction.hpp"
 #include "ActionController.hpp"
 #include <Arduino.h>
 #include "TrainController.hpp"
@@ -8,7 +9,7 @@
 /**
  * Constructor for SequentialAction.
  */
-SequentialAction::SequentialAction() : currentActionIndex(0), isExecuting(false)
+SequentialAction::SequentialAction() : currentActionIndex(0), currentNonBlockingAction(nullptr), isExecuting(false)
 {
     actions.reserve(10);  // Reserve space for 10 actions
 }
@@ -55,7 +56,7 @@ void SequentialAction::execute(TrainController& controller, ActionController& ac
         Serial.println("Starting SequentialAction execution");
         isExecuting = true;
         currentActionIndex = 0;
-        currentDelayedAction.reset();
+        currentNonBlockingAction = nullptr;
     }
     
     // Start the first update cycle - the ActionController will need to call update() 
@@ -99,7 +100,48 @@ bool SequentialAction::update(TrainController& controller, ActionController& act
             continue;
         }
 
-        if (!action->isDelayedAction() && !action->isWaitForPositionAction()) {
+        // Check if the action implements NonBlockingAction interface
+        if (action->isNonBlockingAction()) {
+            if (!currentNonBlockingAction) {
+                // Start the non-blocking action - we need to handle the specific types
+                Serial.print("SequentialAction: Starting non-blocking action #");
+                Serial.println(currentActionIndex);
+                
+                // Since we know it's a non-blocking action, cast to the appropriate type
+                if (action->isDelayedAction()) {
+                    currentNonBlockingAction = static_cast<DelayedAction*>(action.get());
+                } else if (action->isWaitForPositionAction()) {
+                    currentNonBlockingAction = static_cast<WaitForPositionAction*>(action.get());
+                } else if (action->isSequentialAction()) {
+                    currentNonBlockingAction = static_cast<SequentialAction*>(action.get());
+                } else {
+                    Serial.println("Error: Unknown non-blocking action type");
+                    currentActionIndex++;
+                    continue;
+                }
+                
+                // Reset the action to ensure it starts fresh
+                currentNonBlockingAction->reset();
+            }
+
+            // Update the non-blocking action
+            Serial.print("SequentialAction: Updating non-blocking action #");
+            Serial.println(currentActionIndex);
+            if (!currentNonBlockingAction->update(controller, actionController)) {
+                // Still waiting for non-blocking action to complete
+                Serial.println("SequentialAction: Non-blocking action still running, waiting...");
+                Serial.println("SequentialAction: update() returning FALSE (still active)");
+                return false;
+            }
+            
+            // Non-blocking action completed, move to next
+            Serial.print("SequentialAction: Non-blocking action #");
+            Serial.print(currentActionIndex);
+            Serial.println(" completed, moving to next");
+            currentNonBlockingAction = nullptr;
+            currentActionIndex++;
+            continue;
+        } else {
             // Execute immediate action and move to next
             Serial.print("SequentialAction: Executing immediate action #");
             Serial.println(currentActionIndex);
@@ -107,58 +149,8 @@ bool SequentialAction::update(TrainController& controller, ActionController& act
             currentActionIndex++;
             continue;
         }
-
-        if (action->isDelayedAction()) {
-            if (!currentDelayedAction) {
-                // Start the delayed action
-                Serial.print("SequentialAction: Starting delayed action #");
-                Serial.println(currentActionIndex);
-                DelayedAction* delayedAction = static_cast<DelayedAction*>(action.get());
-                currentDelayedAction = delayedAction->createFresh();
-            }
-
-            // Update the delayed action
-            Serial.print("SequentialAction: Updating delayed action #");
-            Serial.println(currentActionIndex);
-            if (!currentDelayedAction->update(controller, actionController)) {
-                // Still waiting for delayed action to complete
-                Serial.println("SequentialAction: Delayed action still running, waiting...");
-                Serial.println("SequentialAction: update() returning FALSE (still active)");
-                return false;
-            }
-            
-            // Delayed action completed, move to next
-            Serial.print("SequentialAction: Delayed action #");
-            Serial.print(currentActionIndex);
-            Serial.println(" completed, moving to next");
-            currentDelayedAction.reset();
-            currentActionIndex++;
-            continue;
-        }
-
-        if (action->isWaitForPositionAction()) {
-            // Handle WaitForPositionAction with non-blocking update
-            Serial.print("SequentialAction: Updating WaitForPositionAction #");
-            Serial.println(currentActionIndex);
-            
-            // Try to cast to WaitForPositionAction to access update method
-            // Note: This requires including the WaitForPositionAction header
-            WaitForPositionAction* waitAction = static_cast<WaitForPositionAction*>(action.get());
-            if (!waitAction->update(controller, actionController)) {
-                // Still waiting for position to be reached
-                Serial.println("SequentialAction: WaitForPositionAction still waiting, returning false");
-                return false;
-            }
-            
-            // Position reached, move to next action
-            Serial.print("SequentialAction: WaitForPositionAction #");
-            Serial.print(currentActionIndex);
-            Serial.println(" completed, moving to next");
-            currentActionIndex++;
-            continue;
-        }
-
     }
+    
     // All actions completed
     Serial.println("SequentialAction: All actions completed");
     Serial.println("SequentialAction: update() returning TRUE (finished)");
@@ -173,7 +165,7 @@ bool SequentialAction::update(TrainController& controller, ActionController& act
 void SequentialAction::reset() {
     isExecuting = false;
     currentActionIndex = 0;
-    currentDelayedAction.reset();
+    currentNonBlockingAction = nullptr;
 }
 
 /**

--- a/src/Action/SequentialAction.cpp
+++ b/src/Action/SequentialAction.cpp
@@ -108,17 +108,7 @@ bool SequentialAction::update(TrainController& controller, ActionController& act
                 Serial.println(currentActionIndex);
                 
                 // Since we know it's a non-blocking action, cast to the appropriate type
-                if (action->isDelayedAction()) {
-                    currentNonBlockingAction = static_cast<DelayedAction*>(action.get());
-                } else if (action->isWaitForPositionAction()) {
-                    currentNonBlockingAction = static_cast<WaitForPositionAction*>(action.get());
-                } else if (action->isSequentialAction()) {
-                    currentNonBlockingAction = static_cast<SequentialAction*>(action.get());
-                } else {
-                    Serial.println("Error: Unknown non-blocking action type");
-                    currentActionIndex++;
-                    continue;
-                }
+                currentNonBlockingAction = static_cast<NonBlockingAction*>(action.get());
                 
                 // Reset the action to ensure it starts fresh
                 currentNonBlockingAction->reset();

--- a/src/Action/SequentialAction.cpp
+++ b/src/Action/SequentialAction.cpp
@@ -107,8 +107,17 @@ bool SequentialAction::update(TrainController& controller, ActionController& act
                 Serial.print("SequentialAction: Starting non-blocking action #");
                 Serial.println(currentActionIndex);
                 
-                // Since we know it's a non-blocking action, cast to the appropriate type
-                currentNonBlockingAction = static_cast<NonBlockingAction*>(action.get());
+                currentNonBlockingAction = action->asNonBlockingAction();
+                
+                // Check if the action supports non-blocking interface
+                if (!currentNonBlockingAction) {
+                    Serial.print("SequentialAction: Error - Action #");
+                    Serial.print(currentActionIndex);
+                    Serial.println(" claims to be non-blocking but doesn't implement NonBlockingAction interface");
+                    // Skip this action and move to the next one
+                    currentActionIndex++;
+                    continue;
+                }
                 
                 // Reset the action to ensure it starts fresh
                 currentNonBlockingAction->reset();


### PR DESCRIPTION
The old implementation manually checked for each type of non-blocking action in the Sequential Action, handling each in essentially the same way.  For clarity, a virtual NonBlockingAction interface has been created and will be implemented by each of the different non-blocking actions.