### PR TITLE
Add arduino-lint.yaml workflow

### DIFF
--- a/.github/workflows/arduino-lint.yaml
+++ b/.github/workflows/arduino-lint.yaml
@@ -1,0 +1,12 @@
+on: [push, pull_request]
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: arduino/arduino-lint-action@v2
+        with:
+          library-manager: submit
+          compliance: strict
+          project-type: library
+          verbose: true


### PR DESCRIPTION
Add a CI/CD workflow with Github Actions to run the Arduino linter in order to check any changes for compatibility with the Arduino library registry.