### PR TITLE
Add Ardu-Badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # LEGO Train Controller
 
+[![arduino-library-badge](https://www.ardu-badge.com/badge/LEGOTrainController.svg?)](https://www.ardu-badge.com/LEGOTrainController)
+
 An Arduino library for controlling LEGO Powered Up trains with automated layouts, sensor-based automation, and intelligent routing.
 
 ## Features


### PR DESCRIPTION
Adds a badge to the README to link to some instructions on how to add to the Arduino IDE.