### PR TITLE
Bugfix 49 - Adds safety checks for optional button pins

### DIFF
--- a/src/Controllers/InputController.cpp
+++ b/src/Controllers/InputController.cpp
@@ -46,8 +46,9 @@ void InputController::setBackwardState(SPEED oldState) {
 }
 
 void InputController::handleButtonInput(SPEED oldState) {
-    const int forwardButtonState = digitalRead(forwardButton);
-    const int backwardButtonState = digitalRead(backwardButton);
+    // Read button states, treating unconfigured pins as not pressed
+    const int forwardButtonState = (forwardButton >= 0) ? digitalRead(forwardButton) : HIGH;
+    const int backwardButtonState = (backwardButton >= 0) ? digitalRead(backwardButton) : HIGH;
 
     // Buttons are active LOW.
     // Default to false if pin not configured.


### PR DESCRIPTION
See issue #49 

Prevents GPIO configuration and reading when button pins are set to invalid values (negative numbers).

Allows InputController to gracefully handle cases where one or both buttons are not physically connected by treating unconfigured pins as permanently unpressed.