### PR TITLE
Hotfix 51 - Switch Arduino Linter mode

### DIFF
--- a/.github/workflows/arduino-lint.yaml
+++ b/.github/workflows/arduino-lint.yaml
@@ -11,7 +11,7 @@ jobs:
           fetch-depth: 0
       - uses: arduino/arduino-lint-action@v2
         with:
-          library-manager: submit
+          library-manager: update
           compliance: strict
           project-type: library
           verbose: true


### PR DESCRIPTION
See #51.

Switched the Arduino Linter into update mode, as errors were occuring before due to the linter thinking it was checking a brand new library.