### PR TITLE
Feature #53 - Adds reverse direction support to train actions

### DIFF
--- a/src/LegoTrainController.cpp
+++ b/src/LegoTrainController.cpp
@@ -96,39 +96,56 @@ void LegoTrainController::addTrackSegment(const SensorLocation& location, const 
     }
 }
 
-void LegoTrainController::addStopAction(const SensorLocation& location, size_t trainIndex, int speed) {
+void LegoTrainController::addStopAction(const SensorLocation& location, const bool reverse, size_t trainIndex, int speed) {
     TrainInstance* train = trainManager.getTrain(trainIndex);
     if (train && train->getPositionTracker()) {
         auto action = std::unique_ptr<SensorAction>(new StopAction(speed));
-        train->getPositionTracker()->addForwardAction(location, std::move(action));
+        if (reverse) {
+
+            train->getPositionTracker()->addReverseAction(location, std::move(action));
+        } else {
+            train->getPositionTracker()->addForwardAction(location, std::move(action));
+        }
     }
 }
 
-void LegoTrainController::addReverseAction(const SensorLocation& location, size_t trainIndex, int speed) {
+void LegoTrainController::addReverseAction(const SensorLocation& location, const bool reverse, size_t trainIndex, int speed) {
     TrainInstance* train = trainManager.getTrain(trainIndex);
     if (train && train->getPositionTracker()) {
         auto action = std::unique_ptr<SensorAction>(new ReverseAction(speed));
-        train->getPositionTracker()->addForwardAction(location, std::move(action));
+        if (reverse) {
+            train->getPositionTracker()->addReverseAction(location, std::move(action));
+        } else {
+            train->getPositionTracker()->addForwardAction(location, std::move(action));
+        }
     }
 }
 
-void LegoTrainController::addSpeedAction(const SensorLocation& location, size_t trainIndex, int speed, int targetSpeed) {
+void LegoTrainController::addSpeedAction(const SensorLocation& location, const bool reverse, size_t trainIndex, int speed, int targetSpeed) {
     TrainInstance* train = trainManager.getTrain(trainIndex);
     if (train && train->getPositionTracker()) {
         auto action = std::unique_ptr<SensorAction>(new SpeedAction(targetSpeed, speed));
-        train->getPositionTracker()->addForwardAction(location, std::move(action));
+        if (reverse) {
+            train->getPositionTracker()->addReverseAction(location, std::move(action));
+        } else {
+            train->getPositionTracker()->addForwardAction(location, std::move(action));
+        }
     }
 }
 
-void LegoTrainController::addSwitchAction(const SensorLocation& location, size_t trainIndex, int switchId, int position, int speed) {
+void LegoTrainController::addSwitchAction(const SensorLocation& location, const bool reverse, size_t trainIndex, int switchId, int position, int speed) {
     TrainInstance* train = trainManager.getTrain(trainIndex);
     if (train && train->getPositionTracker()) {
         auto action = std::unique_ptr<SensorAction>(new SwitchAction(switchId, static_cast<SwitchPosition>(position), speed, &switchController));
-        train->getPositionTracker()->addForwardAction(location, std::move(action));
+        if (reverse) {
+            train->getPositionTracker()->addReverseAction(location, std::move(action));
+        } else {
+            train->getPositionTracker()->addForwardAction(location, std::move(action));
+        }
     }
 }
 
-void LegoTrainController::addSequentialAction(const SensorLocation& location, size_t trainIndex, const std::vector<ActionConfig>& actionConfigs) {
+void LegoTrainController::addSequentialAction(const SensorLocation& location, const bool reverse, size_t trainIndex, const std::vector<ActionConfig>& actionConfigs) {
     TrainInstance* train = trainManager.getTrain(trainIndex);
     if (train && train->getPositionTracker()) {
         std::vector<std::unique_ptr<SensorAction>> actions;
@@ -160,7 +177,11 @@ void LegoTrainController::addSequentialAction(const SensorLocation& location, si
         }
         
         auto sequentialAction = std::unique_ptr<SensorAction>(new SequentialAction(std::move(actions)));
-        train->getPositionTracker()->addForwardAction(location, std::move(sequentialAction));
+        if (reverse) {
+            train->getPositionTracker()->addReverseAction(location, std::move(sequentialAction));
+        } else {
+            train->getPositionTracker()->addForwardAction(location, std::move(sequentialAction));
+        }
     }
 }
 

--- a/src/LegoTrainController.h
+++ b/src/LegoTrainController.h
@@ -204,45 +204,50 @@ public:
     /**
      * Add a stop action at a sensor location
      * @param location Sensor location
+     * @param reverse true if reverse direction, false if forwards
      * @param trainIndex Train index
      * @param speed Speed when stopping (usually 0)
      */
-    void addStopAction(const SensorLocation& location, size_t trainIndex = 0, int speed = 0);
+    void addStopAction(const SensorLocation& location, const bool reverse = false, size_t trainIndex = 0, int speed = 0);
     
     /**
      * Add a reverse action at a sensor location
      * @param location Sensor location
+     * @param reverse true if reverse direction, false if forwards
      * @param trainIndex Train index
      * @param speed Speed when reversing (usually 0)
      */
-    void addReverseAction(const SensorLocation& location, size_t trainIndex = 0, int speed = 0);
-    
+    void addReverseAction(const SensorLocation& location, const bool reverse = false, size_t trainIndex = 0, int speed = 0);
+
     /**
      * Add a speed change action at a sensor location
      * @param location Sensor location
+     * @param reverse true if reverse direction, false if forwards
      * @param trainIndex Train index
      * @param speed Current speed during action
      * @param targetSpeed New speed to set
      */
-    void addSpeedAction(const SensorLocation& location, size_t trainIndex, int speed, int targetSpeed);
+    void addSpeedAction(const SensorLocation& location, const bool reverse = false, size_t trainIndex = 0, int speed = 0, int targetSpeed = 0);
     
     /**
      * Add a switch operation action at a sensor location
      * @param location Sensor location
+     * @param reverse true if reverse direction, false if forwards
      * @param trainIndex Train index
      * @param switchId Switch ID
      * @param position Switch position (STRAIGHT or DIVERGED)
      * @param speed Speed during switch operation
      */
-    void addSwitchAction(const SensorLocation& location, size_t trainIndex, int switchId, int position, int speed = 0);
+    void addSwitchAction(const SensorLocation& location, const bool reverse = false, size_t trainIndex = 0, int switchId = 0, int position = 0, int speed = 0);
     
     /**
      * Add a sequence of actions at a sensor location
      * @param location Sensor location
+     * @param reverse true if reverse direction, false if forwards
      * @param trainIndex Train index
      * @param actionConfigs Vector of action configurations
      */
-    void addSequentialAction(const SensorLocation& location, size_t trainIndex, const std::vector<ActionConfig>& actionConfigs);
+    void addSequentialAction(const SensorLocation& location, const bool reverse = false, size_t trainIndex = 0, const std::vector<ActionConfig>& actionConfigs);
     
     // ===== Status and Debugging =====
     


### PR DESCRIPTION
See #53.

Enables actions to be triggered when trains move in reverse direction by adding a reverse parameter to all action methods.

Previously actions could only be registered for forward movement. Now actions can be configured for either forward or reverse travel direction, providing better control over bidirectional train operations.