### PR TITLE
Hotfix - Specify dependency versions for stability

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -7,7 +7,7 @@ paragraph=This library provides a complete framework for building automated LEGO
 category=Device Control
 url=https://github.com/IwanIDev/lego-arduino-train
 architectures=esp32
-depends=NimBLE-Arduino, Legoino
+depends=NimBLE-Arduino (=1.4.3), Legoino (=1.1.0)
 includes=LegoTrainController.h
 license=MIT
 repository=https://github.com/IwanIDev/lego-arduino-train.git


### PR DESCRIPTION
Specifies exact versions for NimBLE-Arduino (1.4.3) and Legoino (1.1.0) dependencies to ensure consistent builds and prevent potential compatibility issues from automatic updates.